### PR TITLE
Fix that all new questions all have ID 1

### DIFF
--- a/model/src/main/java/mops/fragen/MultipleChoiceFrage.java
+++ b/model/src/main/java/mops/fragen/MultipleChoiceFrage.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Random;
 import lombok.Getter;
 import lombok.Setter;
 import mops.antworten.MultipleChoiceAntwort;
@@ -29,7 +30,7 @@ public class MultipleChoiceFrage extends Frage {
   }
 
   public MultipleChoiceFrage(String fragentext) {
-    super(1L);
+    super(Long.valueOf(new Random().nextInt(1000)));
     this.fragentext = fragentext;
     this.choices = new ArrayList<>();
     fillDummyChoices();

--- a/model/src/main/java/mops/fragen/TextFrage.java
+++ b/model/src/main/java/mops/fragen/TextFrage.java
@@ -2,6 +2,7 @@ package mops.fragen;
 
 import java.util.HashSet;
 import java.util.Optional;
+import java.util.Random;
 import java.util.Set;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
@@ -21,7 +22,7 @@ public class TextFrage extends Frage {
   }
 
   public TextFrage(String fragentext) {
-    super(1L);
+    super(Long.valueOf(new Random().nextInt(1000)));
     this.fragentext = fragentext;
     this.antworten = new HashSet<>();
   }


### PR DESCRIPTION
Someone edited my question classes so that all questions that are generated in the UI have ID 1....
It should be clear, that this is a stupid idea.......
This fix re-introduces the random ID-generator.